### PR TITLE
Add mru1 parser

### DIFF
--- a/echolab2/instruments/util/mru1_motion_data.py
+++ b/echolab2/instruments/util/mru1_motion_data.py
@@ -1,0 +1,225 @@
+# coding=utf-8
+
+#     National Oceanic and Atmospheric Administration (NOAA)
+#     Alaskan Fisheries Science Center (AFSC)
+#     Resource Assessment and Conservation Engineering (RACE)
+#     Midwater Assessment and Conservation Engineering (MACE)
+
+#  THIS SOFTWARE AND ITS DOCUMENTATION ARE CONSIDERED TO BE IN THE PUBLIC DOMAIN
+#  AND THUS ARE AVAILABLE FOR UNRESTRICTED PUBLIC USE. THEY ARE FURNISHED "AS IS."
+#  THE AUTHORS, THE UNITED STATES GOVERNMENT, ITS INSTRUMENTALITIES, OFFICERS,
+#  EMPLOYEES, AND AGENTS MAKE NO WARRANTY, EXPRESS OR IMPLIED, AS TO THE USEFULNESS
+#  OF THE SOFTWARE AND DOCUMENTATION FOR ANY PURPOSE. THEY ASSUME NO RESPONSIBILITY
+#  (1) FOR THE USE OF THE SOFTWARE AND DOCUMENTATION; OR (2) TO PROVIDE TECHNICAL
+#  SUPPORT TO USERS.
+"""
+| Developed by:  oyvind olsen
+| just copied motion_data and added lat/long
+| for MRU1 types 
+"""
+
+import numpy as np
+from ...ping_data import ping_data
+
+
+class mru1_motion_data(object):
+    '''
+    The motion_data class stores pitch, roll, heave, heading, latitude and longitude data
+    and provides a method to interpolate the data to your ping times.
+    '''
+
+    CHUNK_SIZE = 500
+
+    def __init__(self):
+
+        # Create a counter to keep track of the number of datagrams.
+        self.n_raw = 0
+
+        # Create arrays to store MRU0 data
+        self.times = np.empty(mru1_motion_data.CHUNK_SIZE, dtype='datetime64[ms]')
+        self.heave = np.empty(mru1_motion_data.CHUNK_SIZE, dtype='f')
+        self.pitch = np.empty(mru1_motion_data.CHUNK_SIZE, dtype='f')
+        self.roll = np.empty(mru1_motion_data.CHUNK_SIZE, dtype='f')
+        self.heading = np.empty(mru1_motion_data.CHUNK_SIZE, dtype='f')
+        self.latitude = np.empty(mru1_motion_data.CHUNK_SIZE, dtype='f')
+        self.longitude = np.empty(mru1_motion_data.CHUNK_SIZE, dtype='f')
+
+    def add_datagram(self, time, heave, pitch, roll, heading, latitude, longitude):
+        """
+        Add MRU1 datagram data. (copied from above)
+
+        Args:
+            time (datetime64)
+            heave (float)
+            pitch (float)
+            roll (float)
+            heading (float)
+            latitude (float)
+            longitude (float)
+        """
+
+        # Check if this datagram has the same time as the previous - This
+        # simply filters replicate data when used with the EK60 class.
+        if self.times[self.n_raw - 1] ==  time:
+            # We already have this motion datagram stored.
+            return
+
+        # Check if we need to resize our arrays.
+        if self.n_raw == self.times.shape[0]:
+            self._resize_arrays(self.times.shape[0] + mru1_motion_data.CHUNK_SIZE)
+
+        # Add this datagram to our data arrays
+        self.times[self.n_raw] = time
+        self.heave[self.n_raw] = heave
+        self.pitch[self.n_raw] = pitch
+        self.roll[self.n_raw] = roll
+        self.heading[self.n_raw] = heading
+        self.latitude[self.n_raw] = latitude
+        self.longitude[self.n_raw] = longitude
+
+        # Increment datagram counter.
+        self.n_raw += 1
+
+
+    def interpolate(self, p_data, data_type):
+        """
+        interpolate returns the requested motion data interpolated to the ping times
+        that are present in the provided ping_data object.
+
+            p_data is a ping_data object that contains the ping_time vector
+                    to interpolate to.
+            data_type is a string pecifying the motion attribute to interpolate, valid
+                    values are: 'pitch', 'heave', 'roll', and 'heading'
+            attributes is a string or list of strings specifying the motion attribute(s)
+                    to interpolate and return. If None, all attributes are interpolated
+                    and returned.
+
+        Returns a dictionary of numpy arrays keyed by attribute name that contain the
+        interpolated data for that attribute.
+        """
+        # Create the dictionary to return
+        out_data = {}
+
+        # Check if we're been given specific attributes to interpolate
+        if data_type is None:
+            # No - interpolate all
+            attributes = ['heave', 'pitch', 'roll', 'heading', 'latitude', 'longitude']
+        elif isinstance(data_type, str):
+            # We have a string, put it in a list
+            attributes = [data_type]
+
+        #  check if the times are to be grabbed from a ping_data object
+        if isinstance(p_data, ping_data):
+            new_times = p_data.ping_time
+        else:
+            # If not a ping_data object, assume we've just been given times
+            new_times = p_data
+
+        # Work through the attributes and interpolate
+        for attribute in attributes:
+            try:
+                # Interpolate this attribute using the time vector in the
+                # provided ping_data object
+                out_data[attribute] = np.interp(new_times.astype('d'),
+                        self.times.astype('d'), getattr(self, attribute),
+                        left=0, right=0)
+            except:
+                # Provided attribute doesn't exist
+                out_data[attribute] = None
+
+        return (attributes, out_data)
+
+
+    def get_indices(self, start_time=None, end_time=None, time_order=True):
+        """
+        Return index of data contained in speciofied time range.
+
+        get_indices returns an index array containing the indices contained
+        in the range defined by the times provided. By default the indexes
+        are in time order.
+
+        Args:
+            start_time is a datetime or datetime64 object defining the starting
+                time of the data to return. If None, the start time is the
+                earliest time.
+            end_time is a datetime or datetime64 object defining the ending time
+                of the data to return. If None, the end time is the latest time.
+            time_order (bool): Control whether if indexes are returned in time
+                order (True) or not.
+
+        Returns: Index array containing indices of data to return.
+
+        """
+        #  Ensure that we have times to work with.
+        if start_time is None:
+            start_time = np.min(self.times)
+        if end_time is None:
+            end_time = np.max(self.times)
+
+        # Sort time index if returning time ordered indexes.
+        if time_order:
+            primary_index = self.times.argsort()
+        else:
+            primary_index = self.times
+
+        # Determine the indices of the data that fall within the time span
+        # provided.
+        mask = self.times[primary_index] >= start_time
+        mask = np.logical_and(mask, self.times[primary_index] <= end_time)
+
+        #  and return the indices that are included in the specified range
+        return primary_index[mask]
+
+
+    def _resize_arrays(self, new_size):
+        """
+        Resize arrays if needed to hold more data.
+
+        _resize_arrays expands our data arrays and is called when said arrays
+        are filled with data and more data need to be added.
+
+        Args:
+            new_size (int): New size for arrays, Since these are all 1d
+            arrays the value is simply an integer.
+
+        """
+
+        self.times = np.resize(self.times,(new_size))
+        self.pitch = np.resize(self.pitch,(new_size))
+        self.roll = np.resize(self.roll,(new_size))
+        self.heading = np.resize(self.heading,(new_size))
+        self.heave = np.resize(self.heave,(new_size))
+        self.latitude = np.resize(self.latitude,(new_size))
+        self.longitude = np.resize(self.longitude,(new_size))
+
+
+    def trim(self):
+        """
+        Trim arrays to proper size after all data are added.
+
+        trim is called when one is done adding data to the object. It
+        removes empty elements of the data arrays.
+        """
+
+        self._resize_arrays(self.n_raw)
+
+
+    def __str__(self):
+        """
+        Reimplemented string method that provides some basic info about the
+        nmea_data object.
+
+        """
+
+        #  print the class and address
+        msg = str(self.__class__) + " at " + str(hex(id(self))) + "\n"
+
+        #  print some more info about the motion_data instance
+        if (self.n_raw > 0):
+            msg = "{0}       MRU data start time: {1}\n".format(msg, self.times[0])
+            msg = "{0}         MRU data end time: {1}\n".format(msg,self.times[self.n_raw-1])
+            msg = "{0}       Number of datagrams: {1}\n".format(msg,self.n_raw+1)
+        else:
+            msg = msg + ("  motion_data object contains no data\n")
+
+        return msg

--- a/echolab2/instruments/util/simrad_parsers.py
+++ b/echolab2/instruments/util/simrad_parsers.py
@@ -43,7 +43,7 @@ from .date_conversion import nt_to_unix
 
 __all__ = ['SimradNMEAParser', 'SimradDepthParser', 'SimradBottomParser',
             'SimradAnnotationParser', 'SimradConfigParser', 'SimradRawParser',
-            'SimradFILParser', 'SimradXMLParser', 'SimradMRUParser']
+            'SimradFILParser', 'SimradXMLParser', 'SimradMRUParser','SimradMRU1Parser']
 
 
 class _SimradDatagramParser(object):
@@ -85,7 +85,7 @@ class _SimradDatagramParser(object):
         else:
             raise TypeError('Expected a dict or str')
 
-        if type_ != self._id:
+        if type_ != self._id[:3]:
             raise ValueError('Expected data of type %s, not %s' %(self._id, type_))
 
         if version not in self._versions:
@@ -602,14 +602,6 @@ class SimradMRUParser(_SimradDatagramParser):
                        ('pitch', 'f'),
                        ('heading', 'f'),
                       ],
-                    1: [('type', '4s'),
-                    ('low_date', 'L'),
-                    ('high_date', 'L'),
-                    ('heave', 'f'),
-                    ('roll', 'f'),
-                    ('pitch', 'f'),
-                    ('heading', 'f'),
-                    ],
                    }
 
         _SimradDatagramParser.__init__(self, "MRU", headers)
@@ -653,7 +645,151 @@ class SimradMRUParser(_SimradDatagramParser):
 
         return struct.pack(datagram_fmt, *datagram_contents)
 
+class SimradMRU1Parser(_SimradDatagramParser):
+    '''
+    EK80 MRU1 datagram contains the following keys:
+    Details here: http://www3.mbari.org/products/mbsystem/formatdoc/KongsbergKmall/EMdgmFormat_RevH/html/kmBinary.html
 
+    StructDatagramHeader    DgHeader; 
+    char                    StartId[4]
+    UINT16                  DgmLength
+    UINT16                  DgmVersion
+    UINT32                  UTCSeconds
+    UINT32                  UTCNanoSeconds
+    UINT32                  Status;       
+    double                  Latitude
+    double                  Longitude
+    float                   EllipsoidHeight
+    float                   Roll
+    float                   Pitch
+    float                   Heading
+    float                   Heave
+    float                   RollRate
+    float                   PitchRate
+    float                   YawRate
+    float                   NorthVelocity
+    float                   EastVelocity
+    float                   DownVelocity
+    float                   LatitudeError
+    float                   LongitudeError
+    float                   HeightError
+    float                   RollError
+    float                   PitchError
+    float                   HeadingError
+    float                   HeaveError 
+    float                   NorthAcceleration
+    float                   EastAcceleration
+    float                   DownAcceleration
+    UINT32                  DelayedHeaveUTCSeconds
+    UINT32                  DelayedHeaveUTCNanoseconds
+    float                   DelayedHeave
+
+    The following methods are defined:
+
+        from_string(str):    parse a raw EK800 MRU1 datagram
+                            (with leading/trailing datagram size stripped)
+
+        to_string():         Returns the datagram as a raw string (including leading/trailing size fields)
+                            ready for writing to disk
+    '''
+
+    def __init__(self):
+        headers = {0: [('type', '4s'),
+                       ('low_date', 'L'),
+                       ('high_date', 'L'),
+                       ('roll', 'f'),
+                       ('pitch', 'f'),
+                       ('heading', 'f'),
+                      ],
+                    1: [
+                    ('type', '4s'),  #Somehow this is part of a header added before the datagram
+                    ('low_date', 'L'),  #Somehow this is part of a header added before the datagram
+                    ('high_date', 'L'),  #Somehow this is part of a header added before the datagram             
+                    ('start_id', '4s'),
+                    ('dgm_length', 'H'),
+                    ('dgm_version', 'H'),
+                    ('utc_seconds', 'I'),
+                    ('utc_nano_seconds', 'I'),
+                    ('status', 'I'),
+                    ('latitude', 'd'),
+                    ('longitude', 'd'),
+                    ('ellipsoid_height', 'f'),
+                    ('roll', 'f'),
+                    ('pitch', 'f'),
+                    ('heading', 'f'),
+                    ('heave', 'f'),
+                    ('roll_rate', 'f'),
+                    ('pitch_rate', 'f'),
+                    ('yaw_rate', 'f'),
+                    ('north_velocity', 'f'),
+                    ('east_velocity', 'f'),
+                    ('down_velocity', 'f'),
+                    ('latitude_error', 'f'),
+                    ('longitude_error', 'f'),
+                    ('height_error', 'f'),
+                    ('roll_error', 'f'),
+                    ('pitch_error', 'f'),
+                    ('heading_error', 'f'),
+                    ('heave_error', 'f'),
+                    ('north_acceleration', 'f'),
+                    ('east_acceleration', 'f'),
+                    ('down_acceleration', 'f'),
+                    ('delayed_heave_utc_seconds', 'H'),
+                    ('delayed_heave_utc_nanoseconds', 'H'),
+                    ('delayed_heave', 'f'),
+                    ],
+                   }
+
+        _SimradDatagramParser.__init__(self, "MRU1", headers)
+
+    def from_string(self, raw_string, bytes_read):
+
+        header = raw_string[:5]
+        header = header.decode()
+        id_, version = self.validate_data_header(header)
+        return self._unpack_contents(raw_string, bytes_read, version=version)
+    
+    def _unpack_contents(self, raw_string, bytes_read, version):
+        '''
+        Unpacks the data in raw_string into dictionary containing MRU1 data
+
+        :param raw_string:
+        :type raw_string: str
+
+        :returns: None
+        '''
+
+        header_fmt = self.header_fmt(version)
+        header_raw = raw_string[:self.header_size(version)]
+        # header_values = struct.unpack(self.header_fmt(version), raw_string[:self.header_size(version)])
+        header_values = struct.unpack(header_fmt,header_raw )
+        data = {}
+
+        for indx, field in enumerate(self.header_fields(version)):
+            data[field] = header_values[indx]
+            if isinstance(data[field], bytes):
+                data[field] = data[field].decode()
+
+        data['timestamp'] = nt_to_unix((data['low_date'], data['high_date']))
+        data['timestamp'] = data['timestamp'].replace(tzinfo=None)
+        data['bytes_read'] = bytes_read
+
+        return data
+
+    def _pack_contents(self, data, version):
+
+        datagram_fmt = self.header_fmt(version)
+        datagram_contents = []
+
+        if version == 0:
+
+            for field in self.header_fields(version):
+                if isinstance(data[field], str):
+                    data[field] = data[field].encode('latin_1')
+                datagram_contents.append(data[field])
+
+        return struct.pack(datagram_fmt, *datagram_contents)
+    
 class SimradIDXParser(_SimradDatagramParser):
     '''
     ER60/EK80 IDX datagram contains the following keys:

--- a/echolab2/instruments/util/simrad_parsers.py
+++ b/echolab2/instruments/util/simrad_parsers.py
@@ -694,12 +694,9 @@ class SimradMRU1Parser(_SimradDatagramParser):
     '''
 
     def __init__(self):
-        headers = {0: [('type', '4s'),
+        headers = {0: [('type', '4s'), # dummy version here since MRU1 has to be version 1
                        ('low_date', 'L'),
                        ('high_date', 'L'),
-                       ('roll', 'f'),
-                       ('pitch', 'f'),
-                       ('heading', 'f'),
                       ],
                     1: [
                     ('type', '4s'),  #Somehow this is part of a header added before the datagram
@@ -742,13 +739,6 @@ class SimradMRU1Parser(_SimradDatagramParser):
 
         _SimradDatagramParser.__init__(self, "MRU1", headers)
 
-    def from_string(self, raw_string, bytes_read):
-
-        header = raw_string[:5]
-        header = header.decode()
-        id_, version = self.validate_data_header(header)
-        return self._unpack_contents(raw_string, bytes_read, version=version)
-    
     def _unpack_contents(self, raw_string, bytes_read, version):
         '''
         Unpacks the data in raw_string into dictionary containing MRU1 data

--- a/echolab2/instruments/util/simrad_parsers.py
+++ b/echolab2/instruments/util/simrad_parsers.py
@@ -136,6 +136,10 @@ class SimradUnknownParser(_SimradDatagramParser):
         headers = {0: [('type', '4s'),
                        ('low_date', 'L'),
                        ('high_date', 'L')
+                      ],
+                    1: [('type', '4s'),
+                       ('low_date', 'L'),
+                       ('high_date', 'L')
                       ]
                   }
         _SimradDatagramParser.__init__(self, dg_type, headers)
@@ -203,6 +207,11 @@ class SimradDepthParser(_SimradDatagramParser):
     '''
     def __init__(self):
         headers = {0: [('type', '4s'),
+                       ('low_date', 'L'),
+                       ('high_date', 'L'),
+                       ('transceiver_count', 'L')
+                      ],
+                    1: [('type', '4s'),
                        ('low_date', 'L'),
                        ('high_date', 'L'),
                        ('transceiver_count', 'L')
@@ -304,6 +313,11 @@ class SimradBottomParser(_SimradDatagramParser):
                      ('low_date', 'L'),
                      ('high_date', 'L'),
                      ('transceiver_count', 'L')
+                     ],
+                     1: [('type', '4s'),
+                     ('low_date', 'L'),
+                     ('high_date', 'L'),
+                     ('transceiver_count', 'L')
                      ]
                 }
         _SimradDatagramParser.__init__(self, "BOT", headers)
@@ -380,6 +394,10 @@ class SimradAnnotationParser(_SimradDatagramParser):
 
     def __init__(self):
         headers = {0: [('type', '4s'),
+                     ('low_date', 'L'),
+                     ('high_date', 'L')
+                     ],
+                     1: [('type', '4s'),
                      ('low_date', 'L'),
                      ('high_date', 'L')
                      ]
@@ -469,6 +487,10 @@ class SimradNMEAParser(_SimradDatagramParser):
 
     def __init__(self):
         headers = {0: [('type', '4s'),
+                             ('low_date', 'L'),
+                             ('high_date', 'L')
+                            ],
+                    1: [('type', '4s'),
                              ('low_date', 'L'),
                              ('high_date', 'L')
                             ]
@@ -579,7 +601,15 @@ class SimradMRUParser(_SimradDatagramParser):
                        ('roll', 'f'),
                        ('pitch', 'f'),
                        ('heading', 'f'),
-                      ]
+                      ],
+                    1: [('type', '4s'),
+                    ('low_date', 'L'),
+                    ('high_date', 'L'),
+                    ('heave', 'f'),
+                    ('roll', 'f'),
+                    ('pitch', 'f'),
+                    ('heading', 'f'),
+                    ],
                    }
 
         _SimradDatagramParser.__init__(self, "MRU", headers)
@@ -650,6 +680,16 @@ class SimradIDXParser(_SimradDatagramParser):
 
     def __init__(self):
         headers = {0: [('type', '4s'),
+                       ('low_date', 'L'),
+                       ('high_date', 'L'),
+                       #('dummy', 'L'),   # There are 4 extra bytes in this datagram
+                       ('ping_number', 'L'),
+                       ('distance', 'd'),
+                       ('latitude', 'd'),
+                       ('longitude', 'd'),
+                       ('file_offset', 'L'),
+                      ],
+                      1: [('type', '4s'),
                        ('low_date', 'L'),
                        ('high_date', 'L'),
                        #('dummy', 'L'),   # There are 4 extra bytes in this datagram
@@ -851,7 +891,11 @@ class SimradXMLParser(_SimradDatagramParser):
         headers = {0: [('type', '4s'),
                         ('low_date', 'L'),
                         ('high_date', 'L')
-                            ]
+                            ],
+                    1: [('type', '4s'),
+                        ('low_date', 'L'),
+                        ('high_date', 'L')
+                        ]
                         }
 
         _SimradDatagramParser.__init__(self, "XML", headers)

--- a/echolab2/instruments/util/simrad_raw_file.py
+++ b/echolab2/instruments/util/simrad_raw_file.py
@@ -107,6 +107,7 @@ class RawSimradFile(BufferedReader):
                       'DEP': simrad_parsers.SimradDepthParser(),
                       'XML': simrad_parsers.SimradXMLParser(),
                       'FIL': simrad_parsers.SimradFILParser(),
+                      'MRU1': simrad_parsers.SimradMRU1Parser(),
                       'MRU': simrad_parsers.SimradMRUParser(),
                       'IDX': simrad_parsers.SimradIDXParser(),
                       }
@@ -351,6 +352,14 @@ class RawSimradFile(BufferedReader):
         #  07/17/22 - RHT - Modified to partially parse unknown datagram types
 
         dgram_type = raw_datagram_string[:3].decode('iso-8859-1')
+
+        # 03/13/23 - OYV - Use separate parser for MRU0 and MRU1
+        # Needs handling here since it is the 4th character that sepreates them
+        if dgram_type == "MRU":
+            full_mru_type = raw_datagram_string[:4].decode('iso-8859-1')
+            if full_mru_type in self.DGRAM_TYPE_KEY.keys() : 
+                dgram_type = full_mru_type
+
         try:
             parser = self.DGRAM_TYPE_KEY[dgram_type]
             nice_dgram = parser.from_string(raw_datagram_string, bytes_read)


### PR DESCRIPTION
Add parser for MRU1 datagrams
Also create fake NMEA GLL message from MRU1 datagram so that CRIMAC-preprocessor will use to make a zarr with valid lat/long. (See https://github.com/CRIMAC-WP4-Machine-learning/CRIMAC-preprocessing) 

Note that resulting zarr can contain nan for many lat/long. This is because CRIMAC-preprocessor does reindexing of "positions" based on the ping-time data, and inserts nan for missing values. 

This fixes issue [https://github.com/CI-CMG/pyEcholab/issues/65](https://github.com/CI-CMG/pyEcholab/issues/65)